### PR TITLE
Allow no return type on expressions

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -27,7 +27,10 @@
         "singleQuote": true,
         "semi": false
       }
-    ]
+    ],
+    "@typescript-eslint/explicit-function-return-type": {
+      "allowExpressions": true
+    }
   },
   "overrides": [
     {


### PR DESCRIPTION
Makes it possible to use a function in an expression without having to declare return type