### PR TITLE
Adds eslint rule for sorting imports

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -7,7 +7,8 @@
   ],
   "plugins": [
     "@typescript-eslint",
-    "prettier"
+    "prettier",
+    "simple-import-sort"
   ],
   "parser": "@typescript-eslint/parser",
   "parserOptions": {
@@ -35,7 +36,8 @@
         "singleQuote": true,
         "semi": false
       }
-    ]
+    ],
+    "simple-import-sort/sort": "error"
   },
   "overrides": [
     {

--- a/bin/setup.ts
+++ b/bin/setup.ts
@@ -2,8 +2,9 @@
 
 import args from 'args'
 import fs from 'fs'
-import util from 'util'
 import path from 'path'
+import util from 'util'
+
 import { initTarget, updateTarget } from '../src/index'
 
 const readdir = util.promisify(fs.readdir)

--- a/package-lock.json
+++ b/package-lock.json
@@ -3072,6 +3072,12 @@
         "prettier-linter-helpers": "^1.0.0"
       }
     },
+    "eslint-plugin-simple-import-sort": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-simple-import-sort/-/eslint-plugin-simple-import-sort-5.0.1.tgz",
+      "integrity": "sha512-s6Hjp9rcIDYT1h7tuTulblbY7+XQNZK+014uUkNJSKRXEHZO2i7CTr16HOpfgD9HDnUOpl0fwphPsr0oxZqgGg==",
+      "dev": true
+    },
     "eslint-scope": {
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-5.0.0.tgz",

--- a/package.json
+++ b/package.json
@@ -54,6 +54,7 @@
     "eslint": "^6.8.0",
     "eslint-config-prettier": "^6.10.0",
     "eslint-plugin-prettier": "^3.1.2",
+    "eslint-plugin-simple-import-sort": "^5.0.1",
     "jest": "^25.1.0",
     "prettier": "^1.19.1",
     "typescript": "^3.7.5"

--- a/src/fsutils.ts
+++ b/src/fsutils.ts
@@ -1,8 +1,8 @@
-import path from 'path'
 import crypto from 'crypto'
 import fs from 'fs'
-import util from 'util'
+import path from 'path'
 import { Stream } from 'stream'
+import util from 'util'
 
 const readFile = util.promisify(fs.readFile)
 

--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -1,9 +1,10 @@
+import childProcess from 'child_process'
+import crypto from 'crypto'
 import fs from 'fs'
 import os from 'os'
 import path from 'path'
-import crypto from 'crypto'
 import util from 'util'
-import childProcess from 'child_process'
+
 import { initTarget } from './index'
 
 const copyFile = util.promisify(fs.copyFile)

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,5 +1,6 @@
 import fs from 'fs'
 import util from 'util'
+
 import log, { forceLog } from './log'
 import { updatePackageJson } from './package-json'
 

--- a/src/package-json.ts
+++ b/src/package-json.ts
@@ -1,4 +1,4 @@
-import { writeFileAtomic, readJsonFile } from './fsutils'
+import { readJsonFile, writeFileAtomic } from './fsutils'
 import log from './log'
 
 const templatePackagesIgnore = ['@connectedcars/setup', '@types/node']

--- a/templates/node/package-lock.json
+++ b/templates/node/package-lock.json
@@ -9167,6 +9167,12 @@
         "prettier-linter-helpers": "^1.0.0"
       }
     },
+    "eslint-plugin-simple-import-sort": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-simple-import-sort/-/eslint-plugin-simple-import-sort-5.0.1.tgz",
+      "integrity": "sha512-s6Hjp9rcIDYT1h7tuTulblbY7+XQNZK+014uUkNJSKRXEHZO2i7CTr16HOpfgD9HDnUOpl0fwphPsr0oxZqgGg==",
+      "dev": true
+    },
     "eslint-scope": {
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-5.0.0.tgz",

--- a/templates/node/package.json
+++ b/templates/node/package.json
@@ -44,6 +44,7 @@
     "eslint": "6.8.0",
     "eslint-config-prettier": "6.10.0",
     "eslint-plugin-prettier": "3.1.2",
+    "eslint-plugin-simple-import-sort": "^5.0.1",
     "jest": "25.1.0",
     "prettier": "1.19.1",
     "typescript": "3.7.5"


### PR DESCRIPTION
This applies the plugin https://www.npmjs.com/package/eslint-plugin-simple-import-sort which groups absolute and relative imports separate and sorts each of them by path.