### PR TITLE
Fixes building of ts files containing "ts"

### DIFF
--- a/src/build.ts
+++ b/src/build.ts
@@ -40,7 +40,7 @@ export async function babelBuild(rootDirs: string[], outDir: string): Promise<Bu
             continue
           }
           const relative = path.relative(fullRootDir, inFile)
-          const outFile = path.join(fullOutDir, relative).replace(/ts(x?)/, 'js$1')
+          const outFile = path.join(fullOutDir, relative).replace(/ts(x?)$/, 'js$1')
           const entry: BuildEntry = {
             inFile,
             outFile,


### PR DESCRIPTION
If you had a file `src/google-sheets.ts`, it would become `build/dist/src/google-sheejs.ts`. This fixes it be only replacing `ts(x?)` at the end of the file name.