### PR TITLE
Enable func-style ESLint rule

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -70,7 +70,8 @@
       }
     ],
     "simple-import-sort/imports": "error",
-    "simple-import-sort/exports": "error"
+    "simple-import-sort/exports": "error",
+    "func-style": ["error", "declaration"]
   },
   "overrides": [
     {

--- a/templates/node/src/index.ts
+++ b/templates/node/src/index.ts
@@ -4,6 +4,8 @@ export function plus(x: number, y: number): number {
     x,
     y
   }
-  const xNum: (x: number) => number = x => x
+  function xNum(x: number): number {
+    return x
+  }
   return xNum(obj.x) + obj.y
 }


### PR DESCRIPTION
Enables the `func-style` lint rule.

The PR https://github.com/connectedcars/node-backend/pull/1253 shows what it looks like for node-backend.

There is [a single case in node-backend](https://github.com/connectedcars/node-backend/blob/c8d27f5738aa3aee3547aadf5c92eeb95a68fd9c/src/jobs/runner.ts#L100) where the rule gives a false positive. It seems that since `this` is used inside an arrow function inside an arrow function ESLint can't figure out that `this` is used and complains.