### PR TITLE
Report stderr in type build

### DIFF
--- a/bin/build.ts
+++ b/bin/build.ts
@@ -20,6 +20,7 @@ async function main(argv: string[]): Promise<number> {
 
   // TODO: Read root dirs from tsconfig
   const promises: Array<Promise<void>> = []
+
   promises.push(
     (async () => {
       await babelBuild(
@@ -43,11 +44,21 @@ main(process.argv)
   .then(exitCode => {
     process.exit(exitCode)
   })
-  .catch(e => {
-    if (e instanceof BuildErrorOutput) {
-      console.error(e.message)
+  .catch(error => {
+    if (error instanceof BuildErrorOutput) {
+      if (error.stdout.length === 0 && error.stderr.length === 0) {
+        console.error('No stdout or stderr output from process')
+      } else {
+        if (error.stdout.length > 0) {
+          console.error(error.stdout)
+        }
+
+        if (error.stderr.length > 0) {
+          console.error(error.stderr)
+        }
+      }
     } else {
-      console.error(e)
+      console.error(error)
     }
     process.exit(255)
   })

--- a/src/package-json.ts
+++ b/src/package-json.ts
@@ -37,6 +37,7 @@ async function readPackageJson(filePath: string): Promise<PackageJson> {
 
 function sortDependencies(dependencies: StringMap): StringMap {
   const tempDevDependencies: StringMap = {}
+  // eslint-disable-next-line no-restricted-syntax
   for (const name of Object.keys(dependencies).sort((a, b) => a.localeCompare(b))) {
     tempDevDependencies[name] = dependencies[name]
   }


### PR DESCRIPTION
[sc-127812]
[sc-127495]
[skip-sc]

Thanks to an idea from Christian, by running `npx tsc --emitDeclarationOnly` in a local docker container for deploy-kubernetes, I could recreate the out-of-memory error and confirm that the error message is being written to stderr which node-setup silently ignores in type builds.